### PR TITLE
Docs: Add Status Badges to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Spring Boot Security & Observability Lab
 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/8132e73dce8a4e74934e4e4a7baffc9a)](https://app.codacy.com/gh/apenlor/spring-boot-security-observability-lab/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![CI Build Status](https://github.com/apenlor/spring-boot-security-observability-lab/actions/workflows/ci.yml/badge.svg)](https://github.com/apenlor/spring-boot-security-observability-lab/actions/workflows/ci.yml)
+[![Latest Release](https://img.shields.io/github/v/tag/apenlor/spring-boot-security-observability-lab)](https://github.com/apenlor/spring-boot-security-observability-lab/tags)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
 This is an advanced, hands-on lab demonstrating the architectural evolution of a modern Java application. We will build
 a system from the ground up, starting with a secure monolith and progressively refactoring it into a fully observable,
 distributed system using cloud-native best practices.


### PR DESCRIPTION
This pull request enhances the main README.md by adding a suite of status badges to the top of the document.

The purpose of these badges is to provide a quick, at-a-glance dashboard of the project's quality, status, and metadata, which is a standard practice for professional repositories.

The following badges have been added:

- Code Quality: Integrates the Codacy badge to provide an objective grade from our static analysis tool.
- CI Build Status: Shows the live pass/fail status of the main branch from our GitHub Actions workflow.
- Latest Tag: Displays the tags and links directly to the GitHub tag page.
- License: Clearly communicates that the project is available under the MIT License.